### PR TITLE
dnpage's solution to function count() needin to check whether query is fluent or eloquent

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -454,7 +454,8 @@ class Datatables
 	private function count()
 	{
 		//Get columns to temp var.
-		$columns = $this->query->getQuery()->columns;
+                $query_type = get_class($this->query) == 'Illuminate\Database\Query\Builder' ? 'fluent' : 'eloquent';
+		$columns = $query_type == 'eloquent' ? $this->query->getQuery()->columns : $this->query->columns;
 		
 		$this->count_all = $this->query->count();
 		


### PR DESCRIPTION
dnpage's solution to function count() needin to check whether query is fluent or eloquent. See issue #8.
