### PR TITLE
WIP: Fixed data type errors when filtering integer column with LIKE statement

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -387,9 +387,9 @@ class Datatables
 
 						if(Config::get('datatables.search.case_insensitive', false)) {
 							$column = $db_prefix . $column;
-							$query->orwhere(DB::raw('LOWER('.$column.')'), 'LIKE', $keyword);
+							$query->orwhere(DB::raw('CAST(LOWER('.$column.') as CHAR)'), 'LIKE', $keyword);
 						} else {
-							$query->orwhere($column, 'LIKE', $keyword);
+							$query->orwhere(DB::raw('CAST('.$column.' as CHAR)'), 'LIKE', $keyword);
 						}
 					}
 				}


### PR DESCRIPTION
You can reproduce this error with [Laravel-4-Bootstrap-Starter-Site](https://github.com/andrew13/Laravel-4-Bootstrap-Starter-Site) application when you filtering comments (http://localhost:8000/admin/comments)
Tested on MySQL, PostgreSQL, SQLite, MS SQL Server and Oracle (http://sqlfiddle.com/#!12/cd1eb/1/0)
