### PR TITLE
Add ability to use AS statement in queries

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -379,6 +379,8 @@ class Datatables
 
 						preg_match('#^(\S*?)\s+as\s+(\S*?)$#si',$copy_this->columns[$i],$matches);
 						$column = empty($matches) ? $copy_this->columns[$i] : $matches[1];
+						if (stripos($column, ' AS ') !== false) 
+							$column = substr($column, stripos($column, ' AS ')+4);
 						$keyword = '%'.Input::get('sSearch').'%';
 
 						if(Config::get('datatables.search.use_wildcards', false)) {


### PR DESCRIPTION
This will add the ability to do an AS statement in your queries and not break the result
e.g. 

$result = DB::table(str_plural($this->model))->where('account_id', '=', 333)->select('id', 'title', DB::raw("LEFT(contents, 40) AS contents"));
return Datatables::of($result)->make();
