### PR TITLE
Pass the Model object to the callback function instead of the row array

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -172,7 +172,7 @@ class Datatables
 				if (is_string($value['content'])):
 					$value['content'] = $this->blader($value['content'], $rvalue);
 				elseif (is_callable($value['content'])):
-					$value['content'] = $value['content']($rvalue);
+					$value['content'] = $value['content']($this->result_object[$rkey]);
 				endif;
 
 				$rvalue = $this->include_in_array($value,$rvalue);
@@ -183,7 +183,7 @@ class Datatables
 				if (is_string($value['content'])):
 					$value['content'] = $this->blader($value['content'], $rvalue);
 				elseif (is_callable($value['content'])):
-					$value['content'] = $value['content']($rvalue);
+					$value['content'] = $value['content']($this->result_object[$rkey]);
 				endif;
 
 				$rvalue[$value['name']] = $value['content'];


### PR DESCRIPTION
This does not break old code because the Model object implements ArrayableInterface. We can still access the callback with

```
function($m) { return $m['id']; }
```

as well as

```
function($m) { return $m->id; }
```

Now though, we can access modified attributes from Eloquent getters as well as relations on each model. A nice easy change without breaking backwards compatibility. :-)
