### PR TITLE
Fixing error introduced by last patch where bindings were lost

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -476,7 +476,8 @@ class Datatables
 	private function count()
 	{
 		//Count the number of rows in the select
-        	$this->count_all = DB::table(DB::raw('('.$this->query->toSql().') AS count_row_table'))->count();
+        	$this->count_all = DB::table(DB::raw('('.$this->query->toSql().') AS count_row_table'))
+        	->setBindings($this->query->getBindings())->count();
 	}
 
 


### PR DESCRIPTION
Like mentioned in issue #53 the new count function loses bindings causing a sql error. this patch fixes that.
