### PR TITLE
Allow classes extending Illuminate\Database\Query\Builder to be used

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -158,7 +158,7 @@ class Datatables
 	private function save_query($query)
 	{
 		$this->query = $query;
-		$this->query_type = get_class($query) == 'Illuminate\Database\Query\Builder' ? 'fluent' : 'eloquent';
+		$this->query_type = $query instanceof Illuminate\Database\Query\Builder ? 'fluent' : 'eloquent';
 		$this->columns = $this->query_type == 'eloquent' ? $this->query->getQuery()->columns : $this->query->columns;
 	}
 
@@ -496,8 +496,7 @@ class Datatables
 	private function count($count  = 'count_all')
 	{
 		//Get columns to temp var.
-		$query_type = get_class($this->query) == 'Illuminate\Database\Query\Builder' ? 'fluent' : 'eloquent';
-		$query  = $query_type == 'eloquent' ? $this->query->getQuery() : $this->query;
+		$query  = $this->query_type == 'eloquent' ? $this->query->getQuery() : $this->query;
 		//Count the number of rows in the select
 		$this->$count = DB::table(DB::raw('('.$query->toSql().') AS count_row_table'))
 		->setBindings($query->getBindings())->count();


### PR DESCRIPTION
In my project, I had to extend 'Illuminate\Database\Query\Builder' (long story), but it is causing my datatables to fail because get_class doesn't match the expected values.

This allows objects from classes extending the core `Builder` class to be used in datatables.
