### PR TITLE
Edit filtering

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -417,13 +417,13 @@ class Datatables
                         }
                         
                         //Set the default filter
-						$filter = 'orwhere';
-						//Check if this column has a filter method, if not, use default
-						if (array_key_exists($this->getColumnName($this->columns[$i]), $this->filter_columns)) {
-							$filter = $this->filter_columns[$this->getColumnName($this->columns[$i])];
-						} 	
+			$filter = 'orwhere';
+			//Check if this column has a filter method, if not, use default
+			if (array_key_exists($this->getColumnName($this->columns[$i]), $this->filter_columns)) {
+				$filter = $this->filter_columns[$this->getColumnName($this->columns[$i])];
+			} 	
 						
-						$column = $db_prefix . $column;
+			$column = $db_prefix . $column;
                         if(Config::get('datatables.search.case_insensitive', false)) {
                             $query->{$filter}(DB::raw('LOWER('.$cast_begin.$column.$cast_end.')'), 'LIKE', strtolower($keyword));
                         } else {
@@ -448,19 +448,19 @@ class Datatables
                 }
 
                 //Set the default filter
-				$filter = 'where';
-				//Check if this column has a filter method, if not, use default
-				if (array_key_exists($this->getColumnName($this->columns[$i]), $this->filter_columns)) {
-					$filter = $this->filter_columns[$this->getColumnName($this->columns[$i])];
-				} 			
+		$filter = 'where';
+		//Check if this column has a filter method, if not, use default
+		if (array_key_exists($this->getColumnName($this->columns[$i]), $this->filter_columns)) {
+			$filter = $this->filter_columns[$this->getColumnName($this->columns[$i])];
+		} 			
 				
-				if(Config::get('datatables.search.case_insensitive', false)) {
-					$column = $db_prefix . $columns[$i];
-					$this->query->{$filter}(DB::raw('LOWER('.$column.')'),'LIKE', strtolower($keyword));
-				} else {
-					$col = strstr($columns[$i],'(')?DB::raw($columns[$i]):$columns[$i];
-					$this->query->{$filter}($col, 'LIKE', $keyword);
-				}
+		if(Config::get('datatables.search.case_insensitive', false)) {
+			$column = $db_prefix . $columns[$i];
+			$this->query->{$filter}(DB::raw('LOWER('.$column.')'),'LIKE', strtolower($keyword));
+		} else {
+			$col = strstr($columns[$i],'(')?DB::raw($columns[$i]):$columns[$i];
+			$this->query->{$filter}($col, 'LIKE', $keyword);
+		}
             }
         }
     }


### PR DESCRIPTION
So here's my changes to allow for a way to change the default "where/orwhere" conditions in the filtering to something else.
If you have a column that uses aggregate functions (like group_concat) and you need to filter by it, then the query needs to use "having" instead of "where". 

Simply add 

```
->filter_column('col_name', 'having')
```

These changes are not tested properly. I tested it only on the project where I needed them and I'm not sure if something else got broken in the way.

PS: Sorry for any mistakes made. This is my first pull request. 
