### PR TITLE
Fixed issue to properly create the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the `bllim/datatables` under the `require` key after that run the `composer 
         "require": {
             "laravel/framework": "4.0.*",
             ...
-            "bllim/datatables": "*"
+            "bllim/datatables": "dev-master"
         }
         ...
     }
@@ -40,7 +40,7 @@ Composer will download the package. After package downloaded, open "app/config/a
 Finally you need to publish a configuration file by running the following Artisan command.
 
 ```php
-$ php artisan config:publish bllim/laravel4-datatables-package
+$ php artisan config:publish bllim/datatables
 ```
 
 ### Usage


### PR DESCRIPTION
When we require

"bllim/datatables": "*"

from composer, it grabs the latest 1.3.3 tag version, but this tag is missing "/src/config/datatables.php" which is needed when we run the artisan command.

There are two ways to fix this:
1.Require the master branch in composer which does contain the file, 
2. Make a new tag with the latest files from master and confirming that it contains the /config file.

Whichever option you chose, the artisan command in the instructions needs to be updated, the current one listed is not the correct one.
