### PR TITLE
Fixed artisan command in latest tag 1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the `bllim/datatables` under the `require` key after that run the `composer 
         "require": {
             "laravel/framework": "4.0.*",
             ...
-            "bllim/datatables": "dev-master"
+            "bllim/datatables": "*"
         }
         ...
     }


### PR DESCRIPTION
This fixes the artisan command with the latest tag

The command listed in the README does not work, it needs to be:
php artisan config:publish bllim/datatables
