### PR TITLE
 Postgress cast statement incorrect

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -391,7 +391,7 @@ class Datatables
 
                         $keyword = '%'.Input::get('sSearch').'%';
 
-                        if(Config::get('datatables.search.use_wildcards', false)) {
+                        if(Config::get('datatables::datatables.search.use_wildcards', false)) {
                             $keyword = $copy_this->wildcard_like_string(Input::get('sSearch'));
                         }
 
@@ -405,7 +405,7 @@ class Datatables
                         }
 
                         $column = $db_prefix . $column;
-                        if(Config::get('datatables.search.case_insensitive', false)) {
+                        if(Config::get('datatables::datatables.search.case_insensitive', false)) {
                             $query->orwhere(DB::raw('LOWER('.$cast_begin.$column.$cast_end.')'), 'LIKE', strtolower($keyword));
                         } else {
                             $query->orwhere(DB::raw($cast_begin.$column.$cast_end), 'LIKE', $keyword);
@@ -424,11 +424,11 @@ class Datatables
             {
                 $keyword = '%'.Input::get('sSearch_'.$i).'%';
 
-                if(Config::get('datatables.search.use_wildcards', false)) {
+                if(Config::get('datatables::datatables.search.use_wildcards', false)) {
                     $keyword = $copy_this->wildcard_like_string(Input::get('sSearch_'.$i));
                 }
 
-                if(Config::get('datatables.search.case_insensitive', false)) {
+                if(Config::get('datatables::datatables.search.case_insensitive', false)) {
                     $column = $db_prefix . $columns[$i];
                     $this->query->where(DB::raw('LOWER('.$column.')'),'LIKE', strtolower($keyword));
                 } else {
@@ -471,7 +471,7 @@ class Datatables
      * @param string $count variable to store to 'count_all' for iTotalRecords, 'display_all' for iTotalDisplayRecords
      * @return null
      */
-	private function count($count = 'count_all')
+    private function count($count = 'count_all')
     {
         //Get columns to temp var.   
         


### PR DESCRIPTION
Hey there,

On Datatables.php:403 you have this

```
 if( DB::getDriverName() === 'pgsql') {
                            $cast_begin = "CAST(";
                            $cast_end = " as TEXT)";
                        }
```

only this results in postress errors when you have a column defined like table.field.

```
 select count(*) as aggregate from (select '1' as row from "user" inner join "user_role" on "user"."id" = "user_role"."user_id" where "user"."deleted_at" is null and "user_role"."office_id" = $1 and "role_id" = $2 and (CAST(user.givenname as TEXT) LIKE $3 or CAST(insertions as TEXT) LIKE $4 or CAST(surname as TEXT) LIKE $5 or CAST(email as TEXT) LIKE $6)) AS count_row_table
```

 if you add come quotes all is well like this

```
 if( DB::getDriverName() === 'pgsql') {
                            $cast_begin = "CAST('";
                            $cast_end = "' as TEXT)";
                        }
```

Thanks!
