### PR TITLE
Making filtering function factor in removed columns

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -393,6 +393,16 @@ class Datatables
             $copy_this = $this;
             $copy_this->columns = $columns;
 
+            for ($i=0,$c=count($copy_this->columns);$i<$c;$i++)
+            {
+                if(in_array($this->getColumnName($copy_this->columns[$i]), $this->excess_columns))
+                {
+                    unset($copy_this->columns[$i]);
+                }
+            }
+
+            $copy_this->columns = array_values($copy_this->columns);
+
             $this->query->where(function($query) use ($copy_this) {
 
                 $db_prefix = $copy_this->database_prefix();


### PR DESCRIPTION
The filtering function does not factor in removed columns.

If I set bSearchable to false on a specific column, and use remove_column, the wrong column is set to not be searchable.

This corrects that.
