### PR TITLE
Add backticks to columns

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -507,7 +507,12 @@ class Datatables
                                 $cast_end = " as TEXT)";
                             }
                         
-                            $column = $db_prefix . $columns_clean[$i];
+                            // add backticks to columns, needed in order to work around (mysql) reserved words
+                            $column = explode('.',$db_prefix . $columns_clean[$i]);
+                            foreach ($column as $key => $value)
+                                $column[$key] = "`".$value."`";
+                            $column = implode('.',$column);
+                            
                             if(Config::get('datatables.search.case_insensitive', false)) {
                                 $query->orwhere(DB::raw('LOWER('.$cast_begin.$column.$cast_end.')'), 'LIKE', strtolower($keyword));
                             } else {


### PR DESCRIPTION
Fix for searching when you are running this on a table with column names that are reserved words, e.g. 'key' or 'values'. Otherwise you will get a 500 server error.

There is another query around line 570 that I think also needs to be updated but I haven't tested this.
$column = $db_prefix . $columns_clean[$i];

will need to be replaced with

// add backticks to columns, needed in order to work around (mysql) reserved words
$column = explode('.',$db_prefix . $columns_clean[$i]);
foreach ($column as $key => $value)
  $column[$key] = "`".$value."`";
$column = implode('.',$column);
