### PR TITLE
Allowing trailing whitespace

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -473,7 +473,7 @@ class Datatables
         $return = array();
         foreach ( $cols as $i=> $col )
         {
-            preg_match('#^(.*?)\s+as\s+(\S*?)$#si',$col,$matches);
+            preg_match('#^(.*?)\s+as\s+(\S*?)\s*$#si',$col,$matches);
             $return[$i] = empty($matches) ? ($use_alias?$this->getColumnName($col):$col) : $matches[$use_alias?2:1];
         }
 


### PR DESCRIPTION
```
    $distributors = DB::table('distributors')
        ->select(
            'distributors.id',
            'distributors.company_name',
            DB::raw('
                CONCAT_WS(\', \',
                    IF(LENGTH(`address_1`), `address_1`, NULL),
                    IF(LENGTH(`address_2`), `address_2`, NULL),
                    IF(LENGTH(`city`), `city`, NULL),
                    IF(LENGTH(`state`), `state`, NULL),
                    IF(LENGTH(`zip`), `zip`, NULL)
                ) AS address
            '),
            DB::raw('
                (
                    SELECT COUNT(*)
                    FROM redemptions
                    WHERE redemptions.distributor_id = distributors.id
                ) AS redemption_count
            ')
        );
```

I like to format my DB::raws with space at the end.  It would be great if the clean_columns regex accommodated this as per my commit.  Thanks.
