### PR TITLE
Fix bug where $this->columns is set to null instead of [] if selected...

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -99,7 +99,7 @@ class Datatables
     /**
      * Gets query and returns instance of class
      *
-     * @return null
+     * @return Datatables
      */
     public static function of($query)
     {
@@ -111,7 +111,7 @@ class Datatables
     /**
      * Organizes works
      *
-     * @return null
+     * @return array|json
      */
     public function make($mDataSupport=false,$raw=false)
     {
@@ -198,10 +198,10 @@ class Datatables
     }
 
     /**
-    * Adds column filter to filter_columns
-    *
-    * @return $this
-    */
+     * Adds column filter to filter_columns
+     *
+     * @return $this
+     */
     public function filter_column($column,$method)
     {
         $params = func_get_args();
@@ -269,9 +269,9 @@ class Datatables
             foreach ($this->extra_columns as $key => $value) {
 
                 if (is_string($value['content'])):
-                $value['content'] = $this->blader($value['content'], $rvalue);
+                    $value['content'] = $this->blader($value['content'], $rvalue);
                 elseif (is_callable($value['content'])):
-                $value['content'] = $value['content']($this->result_object[$rkey]);
+                    $value['content'] = $value['content']($this->result_object[$rkey]);
                 endif;
 
                 $rvalue = $this->include_in_array($value,$rvalue);
@@ -280,9 +280,9 @@ class Datatables
             foreach ($this->edit_columns as $key => $value) {
 
                 if (is_string($value['content'])):
-                $value['content'] = $this->blader($value['content'], $rvalue);
+                    $value['content'] = $this->blader($value['content'], $rvalue);
                 elseif (is_callable($value['content'])):
-                $value['content'] = $value['content']($this->result_object[$rkey]);
+                    $value['content'] = $value['content']($this->result_object[$rkey]);
                 endif;
 
                 $rvalue[$value['name']] = $value['content'];
@@ -637,7 +637,7 @@ class Datatables
                             $this->query,
                             $this->filter_columns[$columns_copy[$i]]['method']
                         ),
-                            $this->inject_variable(
+                        $this->inject_variable(
                             $this->filter_columns[$columns_copy[$i]]['parameters'],
                             $this->input['columns'][$i]['search']['value']
                         )
@@ -696,8 +696,8 @@ class Datatables
      * @param string $count variable to store to 'count_all' for iTotalRecords, 'display_all' for iTotalDisplayRecords
      * @return null
      */
-     protected function count($count  = 'count_all')
-     {   
+    protected function count($count  = 'count_all')
+    {
 
         //Get columns to temp var.
         if($this->query_type == 'eloquent') {
@@ -747,15 +747,15 @@ class Datatables
         }
 
         $this->$count = DB::connection($connection)
-        ->table(DB::raw('('.$myQuery->toSql().') AS count_row_table'))
-        ->setBindings($myQuery->getBindings())->count();
+            ->table(DB::raw('('.$myQuery->toSql().') AS count_row_table'))
+            ->setBindings($myQuery->getBindings())->count();
 
     }
 
     /**
      * Returns column name from <table>.<column>
      *
-     * @return null
+     * @return string
      */
     protected function getColumnName($str)
     {
@@ -778,7 +778,7 @@ class Datatables
     /**
      * Prints output
      *
-     * @return null
+     * @return array|json
      */
     protected function output($raw=false)
     {


### PR DESCRIPTION
...columns are empty for case of selecting all columns.  Which otherwise causes error "array_values() expects parameter 1 to be array, null given" on line 551.

Add missing mDataProp data from DT1.9 data to column data array.
