### PR TITLE
Add better support for mData.  Now it will properly use the dot notated ...

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -102,7 +102,7 @@ class Datatables
      *
      * @return Datatables
      */
-    public static function of($query, $mDataSupport=false)
+    public static function of($query, $mDataSupport=null)
     {
         $ins = new static;
         $ins->mDataSupport = $mDataSupport;


### PR DESCRIPTION
...data names for the columns if mDataSupport is enabled.  Dot notated columns can be edited and added via the dot notation, and eager joined relations are properly returned with dot notation.  If any table column names are returned with dot aliases, they are converted into the dot notation array.
