### PR TITLE
Fixes 'Creating default object from empty value' error

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -972,7 +972,7 @@ class Datatables
         }
 
         // Clear the orders, since they are not relevant for count
-        $myQuery->orders = null;
+        $countQuery->orders = null;
 
         $this->$count = DB::connection($connection)
             ->table(DB::raw('(' . $countQuery->toSql() . ') AS count_row_table'))


### PR DESCRIPTION
$myQuery wasn't defined previously, $countQuery was.
