### PR TITLE
Fixed PHP < 5.5 compatibility with arbitrary expressions.

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -905,11 +905,12 @@ class Datatables
 
         $names[] = $query->from;
         $joins = $query->joins?:array();
+        $databasePrefix = $this->databasePrefix();
         foreach ($joins as $join) {
             $table = preg_split("/ as /i", $join->table);
             $names[] = $table[0];
-            if (isset($table[1]) && !empty($this->databasePrefix()) && strpos($table[1], $this->databasePrefix()) == 0) {
-                $names[] = preg_replace('/^'.$this->databasePrefix().'/', '', $table[1]);
+            if (isset($table[1]) && !empty($databasePrefix) && strpos($table[1], $databasePrefix) == 0) {
+                $names[] = preg_replace('/^'.$databasePrefix.'/', '', $table[1]);
             }
         }
 


### PR DESCRIPTION
Fixed issues referenced in #156 dealing with arbitrary expressions and empty() not working in PHP < 5.5
