### PR TITLE
Fixing an issue when searching with UTF8 strings

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -742,7 +742,7 @@ class Datatables
                             $column = $this->prefixColumn($column_names[$i]);
 
                             if (Config::get('datatables::search.case_insensitive', false)) {
-                                $query->orwhere(DB::raw('LOWER(' . $cast_begin . $column . $cast_end . ')'), 'LIKE', strtolower($keyword));
+                                $query->orwhere(DB::raw('LOWER(' . $cast_begin . $column . $cast_end . ')'), 'LIKE', Str::lower($keyword));
                             } else {
                                 $query->orwhere(DB::raw($cast_begin . $column . $cast_end), 'LIKE', $keyword);
                             }
@@ -791,7 +791,7 @@ class Datatables
                     $column = $this->prefixColumn($column_names[$i]);
 
                     if (Config::get('datatables::search.case_insensitive', false)) {
-                        $this->query->where(DB::raw('LOWER(' . $column . ')'), 'LIKE', strtolower($keyword));
+                        $this->query->where(DB::raw('LOWER(' . $column . ')'), 'LIKE', Str::lower($keyword));
                     } else {
                         //note: so, when would a ( be in the columns?  It will break a select if that's put in the columns
                         //without a DB::raw.  It could get there in filter columns, but it wouldn't be delt with here.
@@ -1055,7 +1055,7 @@ class Datatables
      */
     public function __call($name, $arguments)
     {
-        $name = Str::camel(strtolower($name));
+        $name = Str::camel(Str::lower($name));
         if (method_exists($this, $name)) {
             return call_user_func_array(array($this, $name), $arguments);
         } else {


### PR DESCRIPTION
Theres an error when using the search with characters like ā, ē, č, ū, š, etc...
It is because the code uses strtolower instead of mb_strtolower...

It is easily fixed by replacing strtolower function with \Str::lower for example.

See this Issue.. 
https://github.com/bllim/laravel4-datatables-package/issues/167
