### PR TITLE
Fixes pagination occurring even if it is disabled in DataTables.

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -608,7 +608,7 @@ class Datatables
      */
     protected function paging()
     {
-        if (!is_null($this->input['start']) && !is_null($this->input['length'])) {
+        if (!is_null($this->input['start']) && !is_null($this->input['length']) && $this->input['length'] != -1) {
             $this->query->skip($this->input['start'])->take((int)$this->input['length'] > 0 ? $this->input['length'] : 10);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/bllim/laravel4-datatables-package/issues/170. This might not be the cleanest solution, but without knowing if DataTables 1.9 sends a null value or not, this was the easy way to go.