### PR TITLE
ignore unbound columns

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -687,7 +687,7 @@ class Datatables
             $this->query->where(function ($query) use (&$that, $column_aliases, $column_names) {
 
                 for ($i = 0, $c = count($that->input['columns']); $i < $c; $i++) {
-                    if (isset($column_aliases[$i]) && $that->input['columns'][$i]['searchable'] == "true") {
+                    if (isset($column_aliases[$i]) && $that->input['columns'][$i]['searchable'] == "true" && $that->input['columns'][$i]['data'] !== '') {
 
                         // if filter column exists for this columns then use user defined method
                         if (isset($that->filter_columns[$column_aliases[$i]])) {


### PR DESCRIPTION
I had a problem with the search function after I've added some columns where I didn't specify a value for `data`. Here's the code I've used to set up my data table:

```javascript
        var table = $("#users-list").DataTable({
            "processing": true,
            "serverSide": true,
            "ajax": "/admin/users/data",
            "order": [[1,'desc']],
            "columnDefs": [ {
                "targets": "_all",
                "defaultContent": ""
            } ],
            "columns": [
                { "data" : "id",               "title" : "{{{ trans('admin.id') }}}", "orderable": true, "searchable": false },
                { "data" : "username",         "title" : "{{{ trans('admin.username') }}}", "orderable": true, "searchable": true },
                { "data" : "email",            "title" : "{{{ trans('admin.email')  }}}", "orderable": true, "searchable": true },
                { "data" : "created_at",       "title" : "{{{ trans('admin.created_at')  }}}", "orderable": true, "searchable": true },
                { "data" : "updated_at",       "title" : "{{{ trans('admin.updated_at')  }}}", "orderable": true, "searchable": true },
                {
                    data: null,
                    className: "center",
                    defaultContent: '<a href="" class="edit btn btn-primary">{{{ trans('admin.edit') }}}</a> <a href="" class="btn btn-default">{{{ trans('admin.delete') }}}</a>'
                }
            ]
        });
```

your package was trying to search for the last column with `data: null` too which failed with an invalid SQL query `LOWER()`. I'm not entirely sure about the best way to fix this problem, didn't have time to analyse your code from the start, but the fix I've made seems to work.